### PR TITLE
Fixed bug  with clearing output file

### DIFF
--- a/MapReduce/FileManagement.cpp
+++ b/MapReduce/FileManagement.cpp
@@ -86,6 +86,10 @@ void FileManagement::readFromFile( ifstream& fileStream, string& data)
 
 
 
-void FileManagement::clearFile(ofstream& fileStream) { fileStream.clear(); }
+void FileManagement::clearFile(ofstream& fileStream, const string& userFile) 
+{
+	fileStream.open(userFile); 
+	closeOutputFile(fileStream);
+}
 void FileManagement::closeInputFile(ifstream& fileToClose) { fileToClose.close(); }
 void FileManagement::closeOutputFile(ofstream& fileToClose){ fileToClose.close(); }

--- a/MapReduce/FileManagement.h
+++ b/MapReduce/FileManagement.h
@@ -55,7 +55,7 @@ public:
 
 	void readFromFile(ifstream& fileStream, string& data);
 
-	void clearFile(ofstream& fileStream);
+	void clearFile(ofstream& fileStream, const string& userFile);
 
 
 private:

--- a/MapReduce/Workflow.cpp
+++ b/MapReduce/Workflow.cpp
@@ -41,8 +41,7 @@ WorkFlow::WorkFlow(string inputFile, string intermediateFile, string outputFile)
 	FileManagement FileStreamSystem;
 	FileStreamSystem.openFileInstream(inputFileStream, inputFile);
 	FileStreamSystem.fileCorrupt(inputFileStream);
-	FileStreamSystem.clearFile(intermediateFileStream);
-	FileStreamSystem.closeOutputFile(intermediateFileStream);
+	FileStreamSystem.clearFile(intermediateFileStream, intermediateFile);
 	
 	string data{ "Unknown" };
 	while (data !=  "1")
@@ -54,6 +53,10 @@ WorkFlow::WorkFlow(string inputFile, string intermediateFile, string outputFile)
 		}
 
 	}
+	
+
+
+
 	
 	
 	


### PR DESCRIPTION
Fixed bug that would just keep writing to the file. Adjustment to the clearFile() function in FileManagement class.