### PR TITLE
Add check for file name, Add Boost logging

### DIFF
--- a/MapReduce/Executive.cpp
+++ b/MapReduce/Executive.cpp
@@ -15,79 +15,107 @@ Prompt the user to input three directories: input, temporary, and output.
 It will then create a Workflow class object with these file directories.  
 
 
-
-//Namespaces
-using std::cout;
-using std::cin;
-using std::string;
-
-struct Files
-{
-	string inputFile;
-	string intermediateFile;
-	string outputFile;
-
-	Files(){}
-
-	explicit Files(const string input, const string intermediate, const string output)
-		:inputFile{ input }, intermediateFile{ intermediate }, outputFile{ output }
-	{
-
-	}
-
-};
-
-
-
 */
 
 
 //Directives
 #include "Workflow.h"
+#include <Windows.h>
 
 #include <iostream>
 #include <string>
 #include <fstream>
+#include <boost/timer/timer.hpp>
 
+#include <boost/log/core.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/utility/setup/file.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
 
-//Namespaces
+//Name spaces
 using std::cout;
 using std::cin;
 using std::string;
 
-int main(int argc, char* argv[])
-{
-	
-	//Boost logging
-	//BOOST_LOG_TRIVIAL(trace) << "A trace severity message";
-	//BOOST_LOG_TRIVIAL(debug) << "A debug severity message";
-	//BOOST_LOG_TRIVIAL(info) << "An informational severity message";
-	//BOOST_LOG_TRIVIAL(warning) << "A warning severity message";
-	//BOOST_LOG_TRIVIAL(error) << "An error severity message";
-	//BOOST_LOG_TRIVIAL(fatal) << "A fatal severity message";
+namespace logging = boost::log;
+namespace keywords = boost::log::keywords;
 
-	//Initate variables to hold the names of the directory locations
+void init_logging()
+{
+	logging::register_simple_formatter_factory<logging::trivial::severity_level, char>("Severity");
+
+	logging::add_file_log(
+		keywords::file_name = "sample.log",
+		keywords::format = "[%TimeStamp%] [%ThreadID%] [%Severity%] [%ProcessID%] [%LineID%] %Message%"
+	);
+
+	logging::core::get()->set_filter
+	(
+		logging::trivial::severity >= logging::trivial::info
+	);
+
+	logging::add_common_attributes();
+}
+
+int main()
+{
+	init_logging();
+
+	//Boost logging used to log errors, warnings, info, fatals etc.
+	BOOST_LOG_TRIVIAL(trace) << "A trace severity message";
+	BOOST_LOG_TRIVIAL(debug) << "A debug severity message";
+	BOOST_LOG_TRIVIAL(info) << "An informational severity message";
+	BOOST_LOG_TRIVIAL(warning) << "A warning severity message";
+	BOOST_LOG_TRIVIAL(error) << "An error severity message";
+	BOOST_LOG_TRIVIAL(fatal) << "A fatal severity message";
+
+	/* set console output codepage to UTF-8 */
+	if (!SetConsoleOutputCP(CP_UTF8)) {
+		std::cerr << "error: unable to set UTF-8 codepage.\n";
+		return 1;
+	}
+
+	//Start timer
+	boost::timer::auto_cpu_timer t(3, "%w seconds\n");
+	
+	//Initiate variables to hold the names of the directory locations
 	string inputFileName{ "Unknown" };
-	string intermediateFileName{ "Unknwon" };
+	string intermediateFileName{ "Unknown" };
 	string outputFileName{ "Unknown" };
 
 	//Banner Message
 	cout << "*************************************************************************************"
 		<< "\n*\t\t\tWelcome to the MapReduce!                                    *"
 		<< "\n*----------------------------------------------------------------------------------- *"
-		<< "\n*This program will allow a user to input their input input directory                 *"
+		<< "\n*This program will allow a user to input their input directory                       *"
 		<< "\n*where text files are stored and will ultimately produce a single output file that   *"
 		<< "\n*contains a list of words and their associated counts in the originating input files.*"
 		<< "\n**************************************************************************************";
 	cout.flush();
 	//Standalone command-line to get user text file input and output directory location
 	cout << "\nInsert the input directory, intermediate directory, and output directory locations.(Separate by a space)"
-		<< "\n>>>";
-	cin >> inputFileName >> intermediateFileName >> outputFileName;
+		//<< "\n>>>";
+	//cin >> inputFileName >> intermediateFileName >> outputFileName;
+		<< "\nInput File Directory: ";
+	std::getline(cin, inputFileName);
+	cout << "Intermediate File Directory: ";
+	std::getline(cin, intermediateFileName);
+	cout << "Output File Directory: ";
+	std::getline(cin, outputFileName);
 
-	WorkFlow workFlow(inputFileName, intermediateFileName, outputFileName);
-	//WorkFlow workFlow("c:\\FileTest\\Input\\input111.txt", "c:\\FileTest\\Temp\\intermediate.txt", "c:\\FileTest\\Output\\output.txt");//Test example of inputes
+	Workflow workFlow(inputFileName, intermediateFileName, outputFileName);
+
+	//**************Test to insert Directory**************
+	cout << "\n";
+	//WorkFlow workFlow("C:\\Users\\Colton Wilson\\Desktop\\CIS687 OOD\\shakespeare", "intermediate.txt", "output.txt");//Test example of inputs
+
+	//**************Test to insert file**************
+	//WorkFlow workFlow("C:\\Users\\Colton Wilson\\Desktop\\CIS687 OOD\\testFolder\\New Text Document.txt", "intermediate.txt", "output.txt");//Test example of inputs
+
+	//print to screen seconds to complete program
+	cout << "\nTime to complete program: ";
+	for (long i = 0; i < 100000000; ++i)
+		std::sqrt(123.456L); // burn some time
 
 }//End of Program
-
-

--- a/MapReduce/Workflow.h
+++ b/MapReduce/Workflow.h
@@ -9,8 +9,8 @@ Project 1
 Workflow.h
 
 Below is "Workflow" class, which is called by the  main() in Executive.cpp.
-The constructor takes three string direcotry names and saves the strings into private data memebrs.
-The constructior will then tie together all the header files with supporting logic.
+The constructor takes three string directory names and saves the strings into private data members.
+The constructor will then tie together all the header files with supporting logic.
 The public data member functions are setters and getters for each data member.
 
 
@@ -21,83 +21,138 @@ The public data member functions are setters and getters for each data member.
 #define WORKFLOW_H
 
 //Directives
-#include<string>
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <stdexcept> // contains runtime_error
 
 //NameSpaces
+using std::cout;
+using std::cin;
+using std::endl;
 using std::string;
+using std::ifstream;
+using std::vector;
+using std::runtime_error;
+using boost::filesystem::recursive_directory_iterator;
 
-class WorkFlow
+class Workflow
 {
 public:
 	//default constructor
-	WorkFlow();
+	Workflow();
 	//WorkFlow constructor with three parameters: string input file directory, string temporary directory to hold intermediate output files, and string output file
-	WorkFlow(string inputFile, string intermediateFile, string outputFile);
+	Workflow(string inputFile, string intermediateFile, string outputFile);
 
-	//**********Destructor*********
-	~WorkFlow();
 
 	//**********Member Function**********
-	void separateOutputPath(const string userInputFile, const string& fileType);
+
+	//Pre-condition: File is given in directory
+	//Post-condition: NA
+	//Will just read the contents of the one file
+	void inputIsFile(string inputFile, string intermediateFile, string outputFile);
+
+
+	//Pre-condition: Directory is given with no file name
+	//Post-condition: NA
+	//Will read in all files in the directory
+	void inputIsDirectory(string inputFile, string intermediateFile, string outputFile);
+
+
 	//Pre-condition: outputFileLocation has been given
-	//Post-condition: outputFileDirectoryLocation data memeber will have a value
+	//Post-condition: outputFileDirectoryLocation data member will have a value
 	//Separates the directory path from the file name
+	void separateOutputPath(const string userInputFile);
+
+
+	//Pre-condition: input, intermediate, output file directories have been declared. 
+	//Post-condition: directories could be changed if not valid
+	//While loops through each file until they are valid
+	void checkFilesValid(string& inputFile, string& intermediateFile, string& outputFile);
+
+	//Pre-condition: An input file is declared
+	//Post-condition: input file is changed if not valid
+	//Checks if the input file is valid to use
 	bool checkIfFIle(const string& userInputFile);
 
+
+	//Pre-condition: An output has been declared
+	//Post-condition: output file changed if not valid
+	//Checks if the output file is valid to use
 	bool checkOfFIle(const string& userInputFile);
 
 	//**********Setters**********
-	void setInputFileLocation(const string& userInputFile);
+
 	//Pre-condition: None
-	//Post-conditon:inputFileLocation has value updated
+	//Post-condition:inputFileLocation has value updated
 	//update value in inputFileLocation
-	void setIntermediateFileLocation(const string& userIntermediateFile);
+	void setInputFileLocation(const string& userInputFile);
+
+
 	//Pre-condition: None
-	//Post-conditon:intermediateFileLocation has value updated
+	//Post-condition:intermediateFileLocation has value updated
 	//update value in intermediateFileLocation
-	void setOutputFileLocation(const string& userOutputFile);
+	void setIntermediateFileLocation(const string& userIntermediateFile);
+
+
 	//Pre-condition: None
-	//Post-conditon:outputFileLocation has value updated
+	//Post-condition:outputFileLocation has value updated
 	//update value in outputFileLocation
-	void setIntermediateFileDirectoryLocation(const string& userOutputFile);
+	void setOutputFileLocation(const string& userOutputFile);
+
+
 	//Pre-condition: None
-	//Post-conditon:IntermediateFileDirectoryLocation has value updated
-	//update value in IntermediateFileDirectoryLocation
-	void setOutputFileDirectoryLocation(const string& userOutputFile);
-	//Pre-condition: None
-	//Post-conditon:outputFileDirectoryLocation has value updated
+	//Post-condition:outputFileDirectoryLocation has value updated
 	//update value in outputFileDirectoryLocation
+	void setOutputFileDirectoryLocation(const string& userOutputFile);
+	
 
 	//**********Getters**********
-	const string getInputFileLocation(void);
-	//Pre-condition: inputFileLocation has a value
-	//Post-conditon: none
-	//Return the value in inputFileLocation
-	const string getIntermediateFileLocation(void);
-	//Pre-condition: intermediateFileLocation has a value
-	//Post-conditon: none
-	//Return the value in intermediateFileLocation
-	const string getOutputFileLocation(void);
-	//Pre-condition: outputFileLocation has a value
-	//Post-conditon: none
-	//Return the value in outputFileLocation
-	const string getIntermediateFileDirectoryLocation(void);
-	//Pre-condition: IntermediateFileDirectoryLocation has a value
-	//Post-conditon: none
-	//Return the value in IntermediateFileDirectoryLocation
-	const string getOutputFileDirectoryLocation(void);
-	//Pre-condition: outputFileDirectoryLocation has a value
-	//Post-conditon: none
-	//Return the value in outputFileDirectoryLocation
 
+	//Pre-condition: inputFileLocation has a value
+	//Post-condition: none
+	//Return the value in inputFileLocation
+	const string getInputFileLocation(void);
+
+
+	//Pre-condition: intermediateFileLocation has a value
+	//Post-condition: none
+	//Return the value in intermediateFileLocation
+	const string getIntermediateFileLocation(void);
+
+
+	//Pre-condition: outputFileLocation has a value
+	//Post-condition: none
+	//Return the value in outputFileLocation
+	const string getOutputFileLocation(void);
+
+
+	//Pre-condition: outputFileDirectoryLocation has a value
+	//Post-condition: none
+	//Return the value in outputFileDirectoryLocation
+	const string getOutputFileDirectoryLocation(void);
+	
+	//**********Destructor*********
+	~Workflow();
 	
 
 private:
-	string inputFileLocation{ "Unknown" }; //Data member to save location of input text file...just read from
-	string intermediateFileLocation{ "Unknown" };//Data member to save location of intermediate file...will be written and then read
-	string intermediateFileDirectoryLocation{ "Unknown" }; //Data member to save directory information for intermediate file
-	string outputFileLocation{ "Unknown" };//Data member to save location of the output file...will be written too
-	string outputFileDirectoryLocation{ "Unknown" }; //Data member to save directory information for output file
+	
+
+	//Data member to save location of input text file...just read from
+	string inputFileLocation{ "Unknown" };
+
+	//Data member to save location of intermediate file...will be written and then read
+	string intermediateFileLocation{ "Unknown" };
+
+	//Data member to save location of the output file...will be written too
+	string outputFileLocation{ "Unknown" };
+
+	//Data member to save directory information for output file
+	string outputFileDirectoryLocation{ "Unknown" };
+
+	// Boolean variables that determine validity of the files.
 	bool validInputFile{ false };
 	bool validIntermediateFile{ false };
 	bool validOutputFile{ false };


### PR DESCRIPTION
I put in a check to make sure user is giving valid log names. I am not 100% if it will write directories if you don't input files that do not exist. I was also able to get the boost logging going to where it writes the error codes to a file sample.log(Note:this file only exist once the program is complete). I worked on replacing some of the catach parts of the try-catch blocks with this logging. So now it will print to the log instead of showing on screen. Let me know what you think on that, I just tried the workflow.cpp file in case you had another idea.